### PR TITLE
vsg 3.30.0 [fix version issue]

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -11,9 +11,18 @@ source:
   sha256: cd394fa6feebe7aa704a41aed9c743baf701d60807f73d191717dcfa188d240c
 
 build:
-  number: 0
+  number: 1
   noarch: python
-  script: python -m pip install . -vv --no-deps --no-build-isolation
+  script: |
+    # Create a VERSION file with the correct version
+    # because setuptools-git-versioning will not detect
+    # the version from the GitHub archive (not a repository,
+    # there is no tag).
+    echo "${{ version }}" > VERSION
+    # Patch pyproject to use the dynamic version from the
+    # VERSION file rather than a git tag
+    sed -i 's/template = "{tag}"/version_file = "VERSION"/' pyproject.toml
+    python -m pip install . -vv --no-deps --no-build-isolation
   python:
     entry_points:
       - vsg = vsg.__main__:main
@@ -35,12 +44,23 @@ tests:
         - vsg
   - script:
       - vsg --help
+      # Verify correct version of the CLI
+      - vsg --version | grep "${{ version }}"
+      # Verify correct version of the module at runtime
+      - python -c "from importlib.metadata import version; assert(version('${{ name }}')=='${{ version }}')"
       - pytest --no-cov
     files:
       source:
         - bin/
         - docs/
-        - vsg/
+        - vsg/styles/*.yaml
+        - vsg/rules/ranges/preamble_doc.rst
+        - vsg/rules/block_comment/preamble_doc.rst
+        - vsg/rules/length/preamble_doc.rst
+        - vsg/rules/procedure/preamble_doc.rst
+        - vsg/rules/procedure_call/preamble_doc.rst
+        - vsg/rules/when/preamble_doc.rst
+        - vsg/vhdlFile/indent/indent_config.yaml
         - tests/
         - pyproject.toml
     requirements:


### PR DESCRIPTION
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

### Problem

The package results having a wrong version (`0.0.1`) because `setuptools-git-versioning` will not detect the version from the GitHub archive (not a repository, there is no tag).

Have also a look at [this warning from the previous build](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1155010&view=logs&j=7b6f2c87-f3a7-5133-8d84-7c03a75d9dfc&t=9eb77fd2-8ddd-5444-8fc0-71cb28dcb736&l=6313). Search within the same log the string `0.0.1`.

### Steps To reproduce

```
# conda install "vsg=3.30.0" -c conda-forge

...

# vsg --version
VHDL Style Guide (VSG) version: 0.0.1
```

### Proposed Solution

- Create a `VERSION` file with the correct version, and patch `pyproject.toml` to use the dynamic version from the `VERSION` file rather than a git tag.
- Add tests regarding the version of the package (CLI and module)
- Source only the required files for the tests (some `.rst` and `.yaml` file, no source files)