### PR TITLE
fix recipe for osx and win

### DIFF
--- a/recipe/patches/0001-version-patch.patch
+++ b/recipe/patches/0001-version-patch.patch
@@ -3,6 +3,13 @@ From: Lorenzo Pirritano <lpirritano@anaconda.com>
 Date: Thu, 20 Mar 2025 21:52:52 +0100
 Subject: [PATCH] version-patch
 
+Patch pyproject.toml to use the dynamic version from the VERSION file rather than a git tag.
+
+This is because setuptools-git-versioning will not detect the version from the GitHub archive
+(not a repository, and therefore there is no tag).
+
+The file named VERSION with the correct version is created in the script section of the recipe.
+
 ---
  pyproject.toml | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/recipe/patches/0001-version-patch.patch
+++ b/recipe/patches/0001-version-patch.patch
@@ -1,0 +1,25 @@
+From 10e8c4474e2ed9b87f04428d1f2e6f44cc42bf86 Mon Sep 17 00:00:00 2001
+From: Lorenzo Pirritano <lpirritano@anaconda.com>
+Date: Thu, 20 Mar 2025 21:52:52 +0100
+Subject: [PATCH] version-patch
+
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 0f56cea..dfb98e4 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -72,7 +72,7 @@ vsg = "vsg.__main__:main"
+ 
+ [tool.setuptools-git-versioning]
+ enabled = true
+-template = "{tag}"
++version_file = "VERSION"
+ 
+ [tool.setuptools.package-data]
+ "vsg.rules" = [
+-- 
+2.39.1
+

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -27,11 +27,6 @@ build:
       - vsg = vsg.__main__:main
 
 requirements:
-  build:
-    - if: not win
-      then: patch
-    - if: win
-      then: m2-patch
   host:
     - python ${{ python_min }}.*
     - setuptools
@@ -48,10 +43,6 @@ tests:
         - vsg
   - script:
       - vsg --help
-      - if: not win
-        then: vsg --version | grep "${{ version }}"
-      - if: win
-        then: vsg --version | findstr ${{ version }}
       - python -c "from importlib.metadata import version; assert(version('${{ name }}')=='${{ version }}')"
       - pytest --no-cov
     files:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: vsg
-  version: "3.30.0"
+  version: 3.30.0
 
 package:
   name: ${{ name|lower }}
@@ -9,25 +9,29 @@ package:
 source:
   url: https://github.com/jeremiah-c-leary/vhdl-style-guide/archive/refs/tags/${{ version }}.tar.gz
   sha256: cd394fa6feebe7aa704a41aed9c743baf701d60807f73d191717dcfa188d240c
+  patches:
+    - patches/0001-version-patch.patch
 
 build:
-  number: 1
+  number: 2
   noarch: python
-  script: |
+  script:
     # Create a VERSION file with the correct version
     # because setuptools-git-versioning will not detect
     # the version from the GitHub archive (not a repository,
     # there is no tag).
-    echo "${{ version }}" > VERSION
-    # Patch pyproject to use the dynamic version from the
-    # VERSION file rather than a git tag
-    sed -i 's/template = "{tag}"/version_file = "VERSION"/' pyproject.toml
-    python -m pip install . -vv --no-deps --no-build-isolation
+    - echo ${{ version }} > VERSION
+    - python -m pip install . -vv --no-deps --no-build-isolation
   python:
     entry_points:
       - vsg = vsg.__main__:main
 
 requirements:
+  build:
+    - if: not win
+      then: patch
+    - if: win
+      then: m2-patch
   host:
     - python ${{ python_min }}.*
     - setuptools
@@ -44,9 +48,10 @@ tests:
         - vsg
   - script:
       - vsg --help
-      # Verify correct version of the CLI
-      - vsg --version | grep "${{ version }}"
-      # Verify correct version of the module at runtime
+      - if: not win
+        then: vsg --version | grep "${{ version }}"
+      - if: win
+        then: vsg --version | findstr ${{ version }}
       - python -c "from importlib.metadata import version; assert(version('${{ name }}')=='${{ version }}')"
       - pytest --no-cov
     files:
@@ -76,7 +81,10 @@ about:
   summary: Coding style enforcement for VHDL
   license: GPL-3.0-only
   license_file: LICENSE
+  description: |
+    Coding style enforcement for VHDL
   homepage: https://github.com/jeremiah-c-leary/vhdl-style-guide
+  repository: https://github.com/jeremiah-c-leary/vhdl-style-guide
   documentation: https://vhdl-style-guide.readthedocs.io/en/stable/
 
 extra:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

On second thoughts, removing the `sed` command to patch `pyproject.toml` and using a proper patch file to allow builds on Osx and Windows with a more straightforward recipe.

Maybe in conda-forge / noarch context this is not needed. I see the linter complaining about the selectors (used only for the patch and testing).